### PR TITLE
Update style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -153,7 +153,7 @@ div.console {
 }
 
 div.console div.jquery-console-inner { 
-	height:100%; 
+	height:98%; 
 	background:#efefef; 
 	padding:0;
 	overflow:auto 


### PR DESCRIPTION
Stop navigation (clear editor, next page, etc.) and console from overlapping (stopgap fix).

Prior to patch: 
![overlap-old](https://cloud.githubusercontent.com/assets/355741/12080447/8c544824-b25a-11e5-9323-4db9e1512465.png)

With patch: 
![overlap-fix](https://cloud.githubusercontent.com/assets/355741/12080439/498aded6-b25a-11e5-8b33-995f6529e8db.png)
